### PR TITLE
改行コードが LF (\n) だったが、Win環境では CRLF が要求されるため、環境非依存な記述に変更する

### DIFF
--- a/src/test/java/com/example/station1/S1.java
+++ b/src/test/java/com/example/station1/S1.java
@@ -18,7 +18,8 @@ public class S1 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("Hello TechTrain!\n", a);
+        assertEquals("Hello TechTrain!" + br, a);
     }
 }

--- a/src/test/java/com/example/station2/S2.java
+++ b/src/test/java/com/example/station2/S2.java
@@ -18,7 +18,8 @@ public class S2 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("false\n42\n3.141592\n", a);
+        assertEquals("false" + br + "42" + br + "3.141592" + br, a);
     }
 }

--- a/src/test/java/com/example/station3/S3.java
+++ b/src/test/java/com/example/station3/S3.java
@@ -18,7 +18,8 @@ public class S3 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("/^^^^^^^^^^^\\\n|\"TechTrain\"|\n\\___________/\n", a);
+        assertEquals("/^^^^^^^^^^^\\" + br + "|\"TechTrain\"|" + br + "\\___________/" + br, a);
     }
 }

--- a/src/test/java/com/example/station4/S4.java
+++ b/src/test/java/com/example/station4/S4.java
@@ -18,7 +18,8 @@ public class S4 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("true\nfalse\n", a);
+        assertEquals("true" + br + "false" + br, a);
     }
 }

--- a/src/test/java/com/example/station5/S5.java
+++ b/src/test/java/com/example/station5/S5.java
@@ -18,7 +18,8 @@ public class S5 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("39.2\n", a);
+        assertEquals("39.2" + br, a);
     }
 }

--- a/src/test/java/com/example/station6/S6.java
+++ b/src/test/java/com/example/station6/S6.java
@@ -18,7 +18,8 @@ public class S6 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("39.2\n", a);
+        assertEquals("39.2" + br, a);
     }
 }

--- a/src/test/java/com/example/station7/S7.java
+++ b/src/test/java/com/example/station7/S7.java
@@ -18,7 +18,8 @@ public class S7 {
         Main.main(null);
 
         String a = baos.toString();
+        String br = System.getProperty("line.separator");
 
-        assertEquals("34880\n", a);
+        assertEquals("34880"+ br, a);
     }
 }

--- a/src/test/java/com/example/station8/S8.java
+++ b/src/test/java/com/example/station8/S8.java
@@ -14,25 +14,26 @@ public class S8 {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(baos);
         System.setOut(out);
+        String br = System.getProperty("line.separator");
 
         Main.question1(1000);
-        assertEquals("送料800円を追加します\n1800\n", baos.toString());
+        assertEquals("送料800円を追加します" + br + "1800" + br, baos.toString());
         baos.reset();
 
         Main.question1(9000);
-        assertEquals("送料800円を追加します\n9800\n", baos.toString());
+        assertEquals("送料800円を追加します" + br + "9800" + br, baos.toString());
         baos.reset();
 
         Main.question1(9999);
-        assertEquals("送料800円を追加します\n10799\n", baos.toString());
+        assertEquals("送料800円を追加します" + br + "10799" + br, baos.toString());
         baos.reset();
 
         Main.question1(10000);
-        assertEquals("10000\n", baos.toString());
+        assertEquals("10000" + br, baos.toString());
         baos.reset();
 
         Main.question1(20000);
-        assertEquals("20000\n", baos.toString());
+        assertEquals("20000" + br, baos.toString());
         baos.reset();
     }
 
@@ -41,21 +42,22 @@ public class S8 {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(baos);
         System.setOut(out);
+        String br = System.getProperty("line.separator");
 
         Main.question2(1);
-        assertEquals("食品\n", baos.toString());
+        assertEquals("食品" + br, baos.toString());
         baos.reset();
 
         Main.question2(2);
-        assertEquals("家電\n", baos.toString());
+        assertEquals("家電" + br, baos.toString());
         baos.reset();
 
         Main.question2(3);
-        assertEquals("家具\n", baos.toString());
+        assertEquals("家具" + br, baos.toString());
         baos.reset();
 
         Main.question2(99);
-        assertEquals("その他\n", baos.toString());
+        assertEquals("その他" + br, baos.toString());
         baos.reset();
 
         Main.question2(100);

--- a/src/test/java/com/example/station9/S9.java
+++ b/src/test/java/com/example/station9/S9.java
@@ -14,6 +14,7 @@ public class S9 {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(baos);
         System.setOut(out);
+        String br = System.getProperty("line.separator");
 
         Main.test(new int[]{100, 200});
         Main.test(new int[]{1200, 1500, 1400});
@@ -22,6 +23,6 @@ public class S9 {
 
         String a = baos.toString();
 
-        assertEquals("A\nA\nB\nC\n", a);
+        assertEquals("A" + br + "A" + br + "B" + br + "C" + br, a);
     }
 }


### PR DESCRIPTION
LF環境は `\n` でよいが、 CRLF環境では `\r\n` が必要。
環境に依存してしまうので、Systemから取得して利用する形式に変更。
