### PR TITLE
fix encoding errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,4 +37,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>


### PR DESCRIPTION
## 事象
Windows環境にて、クリア判定時に以下のようなエラーが出てくるケースがある

`Error: ENOENT: no such file or directory, open 'c:\Users\user\〜\java-stations\target\surefire-reports\TEST-com.example.station1.S1.xml'`

## エラー要因

ビルド時のコンパイルでエンコーディング関連でエラーが発生していて結果としてテストレポートが出力がされていない。

`この文字(0x〜)は、エンコーディングwindows-31jにマップできません`

## 修正内容

pom.xml に UTF-8 でビルドするように指定する

## 参考

https://maven.apache.org/plugins/maven-resources-plugin/examples/encoding.html